### PR TITLE
Climate entity disabled when heating system is off

### DIFF
--- a/custom_components/open3e/climate.py
+++ b/custom_components/open3e/climate.py
@@ -75,10 +75,10 @@ class Open3eClimate(Open3eEntity, ClimateEntity):
 
     @property
     def available(self):
-        """Return True if entity has a target temperature and the current flow temperature
+        """Return True if the current flow temperature
         is not -3276.8 which is used when the circuit is not connected
         """
-        return self.target_temperature is not None and self.__current_flow_temperature > -1000
+        return self.__current_flow_temperature > -1000
 
     @property
     def hvac_action(self) -> HVACAction:


### PR DESCRIPTION
## Description

Fixed a bug where client entity was disabled because there was no program set when the entity is turned off, which in the end set the target temperature to None.

## Context
Resolves #13 

## Fix

Removed target temp check from the available check.