### PR TITLE
Support for multiple devices

### DIFF
--- a/custom_components/open3e/api.py
+++ b/custom_components/open3e/api.py
@@ -124,11 +124,13 @@ class Open3eMqttClient:
             if subscription is not None:
                 subscription()
 
-    async def async_request_data(self, hass: HomeAssistant, ids: list[int]):
+    async def async_request_data(self, hass: HomeAssistant, device_features: dict[int, list[int]]):
         try:
-            data = ",".join(map(str, ids))
-            await mqtt.async_publish(hass=hass, topic=self.__mqtt_cmd,
-                                     payload=f'{{"mode": "read-json", "data":[{data}]}}')
+            for device in device_features.keys():
+                data = ",".join(map(str, device_features[device]))
+                await mqtt.async_publish(hass=hass, topic=self.__mqtt_cmd,
+                                         payload=f'{{"mode": "read-json", "addr": "{device}", "data":[{data}]}}')
+
         except Exception as exception:
             raise Open3eError(exception)
 
@@ -137,7 +139,8 @@ class Open3eMqttClient:
             hass: HomeAssistant,
             set_programs_feature_id: int,
             program: Program,
-            temperature: float
+            temperature: float,
+            device_id: int
     ):
         try:
             _LOGGER.debug(f"Setting programs of feature ID {set_programs_feature_id}")
@@ -147,7 +150,8 @@ class Open3eMqttClient:
                 payload=self.__write_json_payload(
                     feature_id=set_programs_feature_id,
                     sub_feature=program,
-                    data=temperature
+                    data=temperature,
+                    device_id=device_id
                 )
             )
         except Exception as exception:
@@ -157,7 +161,8 @@ class Open3eMqttClient:
             self,
             hass: HomeAssistant,
             feature_id: int,
-            temperature: float
+            temperature: float,
+            device_id: int
     ):
         try:
             _LOGGER.debug(f"Setting hot water temperature of feature ID {feature_id}")
@@ -166,13 +171,14 @@ class Open3eMqttClient:
                 topic=self.__mqtt_cmd,
                 payload=self.__write_json_payload(
                     feature_id=feature_id,
-                    data=temperature
+                    data=temperature,
+                    device_id=device_id
                 )
             )
         except Exception as exception:
             raise Open3eError(exception)
 
-    async def async_turn_hvac_on(self, hass: HomeAssistant, power_hvac_feature_id: int):
+    async def async_turn_hvac_on(self, hass: HomeAssistant, power_hvac_feature_id: int, device_id: int):
         try:
             _LOGGER.debug(f"Turning HVAC off with feature ID {power_hvac_feature_id}")
             await mqtt.async_publish(
@@ -180,13 +186,14 @@ class Open3eMqttClient:
                 topic=self.__mqtt_cmd,
                 payload=self.__write_raw_payload(
                     feature_id=power_hvac_feature_id,
-                    data="0102"
+                    data="0102",
+                    device_id=device_id
                 )
             )
         except Exception as exception:
             raise Open3eError(exception)
 
-    async def async_turn_hvac_off(self, hass: HomeAssistant, power_hvac_feature_id: int):
+    async def async_turn_hvac_off(self, hass: HomeAssistant, power_hvac_feature_id: int, device_id: int):
         try:
             _LOGGER.debug(f"Turning HVAC off with feature ID {power_hvac_feature_id}")
             await mqtt.async_publish(
@@ -194,14 +201,15 @@ class Open3eMqttClient:
                 topic=self.__mqtt_cmd,
                 payload=self.__write_raw_payload(
                     feature_id=power_hvac_feature_id,
-                    data="0000"
+                    data="0000",
+                    device_id=device_id
                 )
             )
         except Exception as exception:
             raise Open3eError(exception)
 
     async def async_set_dmw_mode(self, hass: HomeAssistant, mode: DmwMode, dmw_state_feature_id: int,
-                                 dmw_efficiency_mode_feature_id: int):
+                                 dmw_efficiency_mode_feature_id: int, device_id: int):
         try:
             _LOGGER.debug(f"Setting DMW mode to {mode}")
 
@@ -224,7 +232,8 @@ class Open3eMqttClient:
                     topic=self.__mqtt_cmd,
                     payload=self.__write_json_payload(
                         feature_id=dmw_state_feature_id,
-                        data=state_payload
+                        data=state_payload,
+                        device_id=device_id
                     )
                 )
 
@@ -234,26 +243,24 @@ class Open3eMqttClient:
                     topic=self.__mqtt_cmd,
                     payload=self.__write_json_payload(
                         feature_id=dmw_efficiency_mode_feature_id,
-                        data=efficiency_payload
+                        data=efficiency_payload,
+                        device_id=device_id
                     )
                 )
         except Exception as exception:
             raise Open3eError(exception)
 
     @staticmethod
-    def __request_json_payload(feature_ids: list[int]):
-        return json_dumps({"mode": "read-json", "data": feature_ids})
-
-    @staticmethod
-    def __write_json_payload(feature_id: int, data: any, sub_feature: str | None = None):
+    def __write_json_payload(feature_id: int, data: any, device_id: int, sub_feature: str | None = None):
         if sub_feature is None:
-            return json_dumps({"mode": "write", "data": [[feature_id, json_dumps(data)]]})
+            return json_dumps({"mode": "write", "addr": device_id, "data": [[feature_id, json_dumps(data)]]})
 
-        return json_dumps({"mode": "write", "data": [[f"{feature_id}.{sub_feature}", json_dumps(data)]]})
+        return json_dumps(
+            {"mode": "write", "addr": device_id, "data": [[f"{feature_id}.{sub_feature}", json_dumps(data)]]})
 
     @staticmethod
-    def __write_raw_payload(feature_id: int, data: str):
-        return json_dumps({"mode": "write-raw", "data": [[feature_id, data]]})
+    def __write_raw_payload(feature_id: int, data: str, device_id: int):
+        return json_dumps({"mode": "write-raw", "addr": device_id, "data": [[feature_id, data]]})
 
     def __set_system(self, message: ReceiveMessage):
         self.__system_information = Open3eDataSystemInformation.from_dict(json_loads(message.payload))

--- a/custom_components/open3e/climate.py
+++ b/custom_components/open3e/climate.py
@@ -131,16 +131,17 @@ class Open3eClimate(Open3eEntity, ClimateEntity):
         await self.coordinator.async_set_program_temperature(
             set_programs_feature_id=self.entity_description.programs_temperature_feature.id,
             program=self.__current_program.map_to_api(),
-            temperature=temperature
+            temperature=temperature,
+            device=self.device
         )
 
     async def async_turn_on(self):
         """Turn the entity on."""
-        await self.coordinator.async_turn_hvac_on(self.entity_description.hvac_mode_feature.id)
+        await self.coordinator.async_turn_hvac_on(self.entity_description.hvac_mode_feature.id, self.device)
 
     async def async_turn_off(self):
         """Turn the entity off."""
-        await self.coordinator.async_turn_hvac_off(self.entity_description.hvac_mode_feature.id)
+        await self.coordinator.async_turn_hvac_off(self.entity_description.hvac_mode_feature.id, self.device)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode):
         """Set new target hvac mode."""

--- a/custom_components/open3e/coordinator.py
+++ b/custom_components/open3e/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .api import Open3eMqttClient
 from .const import DOMAIN
 from .definitions.dmw_mode import DmwMode
-from .definitions.open3e_data import Open3eDataSystemInformation
+from .definitions.open3e_data import Open3eDataSystemInformation, Open3eDataDevice
 from .definitions.program import Program
 from .errors import Open3eCoordinatorUpdateFailed
 
@@ -31,8 +31,9 @@ class CoordinatorEndpoint:
     __last_refresh: float = -1
     __entities_subscribed: int = 1
 
-    def __init__(self, refresh_interval: int):
+    def __init__(self, refresh_interval: int, device: Open3eDataDevice):
         self.refresh_interval = refresh_interval
+        self.device = device
 
     def add_entity_subscription(self):
         self.__entities_subscribed = self.__entities_subscribed + 1
@@ -106,8 +107,8 @@ class Open3eDataUpdateCoordinator(DataUpdateCoordinator):
                 serial_number=device.serial_number,
                 sw_version=device.software_version,
                 hw_version=device.hardware_version,
-                name="Vitocal",
-                model="Vitocal",
+                name=device.name,
+                model=device.name,
             )
 
     def __on_availability_update(self, available: bool):
@@ -118,33 +119,37 @@ class Open3eDataUpdateCoordinator(DataUpdateCoordinator):
         if self.__server_available is None:
             return True
 
-        if self.__server_available is False:
+        if not self.__server_available:
             raise Open3eCoordinatorUpdateFailed()
 
         now = time.time()
 
-        ids = list()
+        device_features: dict[int, list[int]] = {}
 
         for id in self._endpoints.keys():
             if self._endpoints[id].should_refresh(now):
-                ids.append(id)
+                if device_features.get(self._endpoints[id].device.id) is None:
+                    device_features[self._endpoints[id].device.id] = list()
+
+                device_features[self._endpoints[id].device.id].append(id)
                 self._endpoints[id].update_last_refresh(now)
 
-                if len(ids) == 0:
-                    return True
+        if device_features is None:
+            return True
 
-        _LOGGER.debug(f"Requesting data update for features {ids}")
+        _LOGGER.debug(f"Requesting data update for features {device_features}")
 
-        await self.__client.async_request_data(self.hass, ids)
+        await self.__client.async_request_data(self.hass, device_features)
 
         return True
 
-    async def on_entity_added(self, features: list[Feature]):
+    async def on_entity_added(self, features: list[Feature], device: Open3eDataDevice):
         _LOGGER.debug("Entity was added to Coordinator")
         for feature in features:
             if feature.id not in self._endpoints:
                 self._endpoints[feature.id] = CoordinatorEndpoint(
-                    refresh_interval=feature.refresh_interval
+                    refresh_interval=feature.refresh_interval,
+                    device=device
                 )
             else:
                 self._endpoints[feature.id].add_entity_subscription()
@@ -181,43 +186,47 @@ class Open3eDataUpdateCoordinator(DataUpdateCoordinator):
             self,
             set_programs_feature_id: int,
             program: Program,
-            temperature: float
+            temperature: float,
+            device: Open3eDataDevice
     ):
         await self.__client.async_set_program_temperature(
             hass=self.hass,
             set_programs_feature_id=set_programs_feature_id,
             program=program,
-            temperature=temperature
+            temperature=temperature,
+            device_id=device.id
         )
 
         # Wait for 2 seconds to request temperature
         await asyncio.sleep(2)
 
-        await self.__client.async_request_data(self.hass, [set_programs_feature_id])
+        await self.__client.async_request_data(self.hass, {device.id: [set_programs_feature_id]})
 
     async def async_set_hot_water_temperature(
             self,
             feature_id: int,
-            temperature: float
+            temperature: float,
+            device: Open3eDataDevice
     ):
         await self.__client.async_set_hot_water_temperature(
             hass=self.hass,
             feature_id=feature_id,
-            temperature=temperature
+            temperature=temperature,
+            device_id=device.id
         )
 
         # Wait for 2 seconds to request temperature
         await asyncio.sleep(2)
 
-        await self.__client.async_request_data(self.hass, [feature_id])
+        await self.__client.async_request_data(self.hass, {device.id: [feature_id]})
 
-    async def async_turn_hvac_on(self, power_hvac_feature_id: int):
-        await self.__client.async_turn_hvac_on(self.hass, power_hvac_feature_id)
+    async def async_turn_hvac_on(self, power_hvac_feature_id: int, device: Open3eDataDevice):
+        await self.__client.async_turn_hvac_on(self.hass, power_hvac_feature_id, device.id)
         # Wait for 2 seconds to request hvac state
         await asyncio.sleep(2)
 
-    async def async_turn_hvac_off(self, power_hvac_feature_id: int):
-        await self.__client.async_turn_hvac_off(self.hass, power_hvac_feature_id)
+    async def async_turn_hvac_off(self, power_hvac_feature_id: int, device: Open3eDataDevice):
+        await self.__client.async_turn_hvac_off(self.hass, power_hvac_feature_id, device.id)
         # Wait for 2 seconds to request hvac state
         await asyncio.sleep(2)
 
@@ -225,16 +234,21 @@ class Open3eDataUpdateCoordinator(DataUpdateCoordinator):
             self,
             mode: DmwMode,
             dmw_state_feature_id: int,
-            dmw_efficiency_mode_feature_id: int
+            dmw_efficiency_mode_feature_id: int,
+            device: Open3eDataDevice
     ):
         await self.__client.async_set_dmw_mode(
             hass=self.hass,
             mode=mode,
             dmw_state_feature_id=dmw_state_feature_id,
-            dmw_efficiency_mode_feature_id=dmw_efficiency_mode_feature_id
+            dmw_efficiency_mode_feature_id=dmw_efficiency_mode_feature_id,
+            device_id=device.id
         )
 
         # Wait for 2 seconds to request new states
         await asyncio.sleep(2)
 
-        await self.__client.async_request_data(self.hass, [dmw_state_feature_id, dmw_efficiency_mode_feature_id])
+        await self.__client.async_request_data(
+            self.hass,
+            {device.id: [dmw_state_feature_id, dmw_efficiency_mode_feature_id]}
+        )

--- a/custom_components/open3e/entity.py
+++ b/custom_components/open3e/entity.py
@@ -60,7 +60,7 @@ class Open3eEntity(CoordinatorEntity, Entity):
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
-        await self.coordinator.on_entity_added(self.entity_description.poll_data_features)
+        await self.coordinator.on_entity_added(self.entity_description.poll_data_features, self.device)
 
         for mqtt_topic in self.__mqtt_topics:
             await self._async_register_callback(mqtt_topic=mqtt_topic)

--- a/custom_components/open3e/number.py
+++ b/custom_components/open3e/number.py
@@ -62,7 +62,8 @@ class Open3eNumber(Open3eEntity, NumberEntity):
         await self.coordinator.async_set_program_temperature(
             set_programs_feature_id=self.entity_description.poll_data_features[0].id,
             program=self.entity_description.program,
-            temperature=value
+            temperature=value,
+            device=self.device
         )
 
     async def async_on_data(self, feature_id: int) -> None:

--- a/custom_components/open3e/water_heater.py
+++ b/custom_components/open3e/water_heater.py
@@ -94,7 +94,8 @@ class Open3eWaterHeater(Open3eEntity, WaterHeaterEntity):
         temperature = kwargs["temperature"]
         await self.coordinator.async_set_hot_water_temperature(
             feature_id=self.entity_description.temperature_target_feature.id,
-            temperature=temperature
+            temperature=temperature,
+            device=self.device
         )
 
     @property
@@ -112,5 +113,6 @@ class Open3eWaterHeater(Open3eEntity, WaterHeaterEntity):
         await self.coordinator.async_set_hot_water_mode(
             mode=DmwMode.from_ha_preset_mode(operation_mode),
             dmw_state_feature_id=self.entity_description.state_feature.id,
-            dmw_efficiency_mode_feature_id=self.entity_description.efficiency_mode_feature.id
+            dmw_efficiency_mode_feature_id=self.entity_description.efficiency_mode_feature.id,
+            device=self.device
         )


### PR DESCRIPTION
## Description

Updated all API calls to include `addr` property of the device the entity is in so that multiple devices on one config can be supported.

## Context

Resolves #43
