### PR TITLE
Heating circuit pump state always shown as OFF

### DIFF
--- a/custom_components/open3e/definitions/binary_sensors.py
+++ b/custom_components/open3e/definitions/binary_sensors.py
@@ -60,11 +60,11 @@ BINARY_SENSORS: tuple[Open3eBinarySensorEntityDescription, ...] = (
     ),
     Open3eBinarySensorEntityDescription(
         device_class=BinarySensorDeviceClass.POWER,
-        poll_data_features=[Features.State.CircuitPump],
+        poll_data_features=[Features.State.CentralHeatingPump],
         key="circuit_pump",
         translation_key="circuit_pump",
         icon="mdi:water-sync",
-        data_transform=BinarySensorDataTransform.POWERSTATE
+        data_transform=BinarySensorDataTransform.STATE
     ),
     Open3eBinarySensorEntityDescription(
         device_class=BinarySensorDeviceClass.POWER,

--- a/custom_components/open3e/definitions/features.py
+++ b/custom_components/open3e/definitions/features.py
@@ -93,14 +93,13 @@ class Features:
         HeatPumpCompressor = Feature(id=2351, refresh_interval=30)
         Buffer = Feature(id=3070, refresh_interval=30)
         CircuitFrostProtection = Feature(id=2855, refresh_interval=30)
-        CircuitPump = Feature(id=401, refresh_interval=30)
+        CentralHeatingPump = Feature(id=381, refresh_interval=10)
         HotWaterCirculationPump = Feature(id=491, refresh_interval=30)
         DomesticHotWaterCirculationPumpMode = Feature(id=497, refresh_interval=30)
         TargetQuickMode = Feature(id=1006, refresh_interval=30)
         FrostProtection = Feature(id=2489, refresh_interval=30)
 
     class Speed:
-        CentralHeatingPump = Feature(id=381, refresh_interval=10)
         Compressor = Feature(id=2346, refresh_interval=10)
 
     class Position:

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -259,7 +259,7 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         data_retriever=SensorDataRetriever.ACTUAL
     ),
     Open3eSensorEntityDescription(
-        poll_data_features=[Features.Speed.CentralHeatingPump],
+        poll_data_features=[Features.State.CentralHeatingPump],
         device_class=SensorDeviceClass.POWER_FACTOR,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
## Description

Heating circuit pump was always off. I checked my Vitocal and had the same issue even though other yamls suggest they still use the same DID as I did before. I suspect this either being because they changed the structure in a recent update or maybe because of the configuration being different. We will have to see as the time goes on.

## Context

Resolves #53 