### PR TITLE
Add Vitocharge sensors for grid-energy feed-in and supply

### DIFF
--- a/custom_components/open3e/definitions/features.py
+++ b/custom_components/open3e/definitions/features.py
@@ -88,6 +88,7 @@ class Features:
         Cooling = Feature(id=566, refresh_interval=300)
         Battery = Feature(id=1801, refresh_interval=300)
         PV = Feature(id=1802, refresh_interval=300)
+        Grid = Feature(id=535, refresh_interval=300)
         HeatingOutput = Feature(id=1211, refresh_interval=30)
         WarmWaterOutput = Feature(id=1391, refresh_interval=30)
         CoolingOutput = Feature(id=2529, refresh_interval=30)

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -42,6 +42,8 @@ class SensorDataRetriever:
     PV_ENERGY_PRODUCTION_MONTH = lambda data: float(json_loads(data)["PhotovoltaicProductionMonth"])
     PV_ENERGY_PRODUCTION_YEAR = lambda data: float(json_loads(data)["PhotovoltaicProductionYear"])
     PV_ENERGY_PRODUCTION_TOTAL = lambda data: float(json_loads(data)["PhotovoltaicProductionTotal"])
+    GRID_FEED_IN_ENERGY = lambda data: float(json_loads(data)["GridFeedInEnergy"])
+    GRID_SUPPLIED_ENERGY = lambda data: float(json_loads(data)["GridSuppliedEnergy"])
     TEMPERATURE = lambda data: float(json_loads(data)["Temperature"])
     PV_POWER_CUMULATED = lambda data: float(json_loads(data)["ActivePower cumulated"])
     PV_POWER_STRING_1 = lambda data: float(json_loads(data)["ActivePower String A"])
@@ -1048,6 +1050,24 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         key="pv_energy_production_total",
         translation_key="pv_energy_production_total",
         data_retriever=SensorDataRetriever.PV_ENERGY_PRODUCTION_TOTAL
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.Grid],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="grid_feed_in_energy",
+        translation_key="grid_feed_in_energy",
+        data_retriever=SensorDataRetriever.GRID_FEED_IN_ENERGY
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.Grid],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="grid_supplied_energy",
+        translation_key="grid_supplied_energy",
+        data_retriever=SensorDataRetriever.GRID_SUPPLIED_ENERGY
     ),
     Open3eSensorEntityDescription(
         poll_data_features=[Features.Temperature.InverterAmbient],

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -166,6 +166,12 @@
       "pv_energy_production_total": {
         "name": "PV-Energieproduktion Gesamt"
       },
+      "grid_supplied_energy": {
+        "name": "Netz-Energiebezug Gesamt"
+      },
+      "grid_feed_in_energy": {
+        "name": "Netz-Energielieferung Gesamt"
+      },
       "domestic_hot_water_target_temperature": {
         "name": "Warmwasser-Zieltemperatur"
       },

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -166,6 +166,12 @@
       "pv_energy_production_total": {
         "name": "PV Energy Production Total"
       },
+      "grid_supplied_energy": {
+        "name": "Grid Energy Supply Total"
+      },
+      "grid_feed_in_energy": {
+        "name": "Grid Energy Feed-In Total"
+      },
       "domestic_hot_water_target_temperature": {
         "name": "Domestic Hot Water Temperature"
       },


### PR DESCRIPTION
## Description

Add two Vitocharge sensors for Total Grid-Feed-In Energy and Total Grid-Supplied Energy to completely support the HA Energy Dashboard.
