### PR TITLE
duplicated the state_attributes to climate_circuit_2 to _4

### DIFF
--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -136,7 +136,7 @@
       "battery_power_current": {
         "name": "Aktuelle Batterieleistung"
       },
-      "backup_box_installed":{
+      "backup_box_installed": {
         "name": "Backup-Box vorhanden"
       },
       "backup_box_discharge_limit_percentage": {
@@ -672,13 +672,64 @@
         }
       },
       "climate_circuit_2": {
-        "name": "Heiz-Kühlkreis 2"
+        "name": "Heiz-Kühlkreis 2",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Abschaltbetrieb",
+              "reduced": "Reduziert",
+              "normal": "Normal",
+              "comfort": "Komfort",
+              "fixed_value": "Festwert",
+              "frost_protection": "Frostschutz",
+              "eco_reduced": "Energiesparen Reduziert",
+              "eco_normal": "Energiesparen Normal",
+              "eco_comfort": "Energiesparen Komfort",
+              "cooling_normal": "Kühlen Normal",
+              "cooling_comfort": "Kühlen Komfort"
+            }
+          }
+        }
       },
       "climate_circuit_3": {
-        "name": "Heiz-Kühlkreis 3"
+        "name": "Heiz-Kühlkreis 3",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Abschaltbetrieb",
+              "reduced": "Reduziert",
+              "normal": "Normal",
+              "comfort": "Komfort",
+              "fixed_value": "Festwert",
+              "frost_protection": "Frostschutz",
+              "eco_reduced": "Energiesparen Reduziert",
+              "eco_normal": "Energiesparen Normal",
+              "eco_comfort": "Energiesparen Komfort",
+              "cooling_normal": "Kühlen Normal",
+              "cooling_comfort": "Kühlen Komfort"
+            }
+          }
+        }
       },
       "climate_circuit_4": {
-        "name": "Heiz-Kühlkreis 4"
+        "name": "Heiz-Kühlkreis 4",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Abschaltbetrieb",
+              "reduced": "Reduziert",
+              "normal": "Normal",
+              "comfort": "Komfort",
+              "fixed_value": "Festwert",
+              "frost_protection": "Frostschutz",
+              "eco_reduced": "Energiesparen Reduziert",
+              "eco_normal": "Energiesparen Normal",
+              "eco_comfort": "Energiesparen Komfort",
+              "cooling_normal": "Kühlen Normal",
+              "cooling_comfort": "Kühlen Komfort"
+            }
+          }
+        }
       }
     },
     "number": {

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -136,7 +136,7 @@
       "battery_power_current": {
         "name": "Current Battery Load"
       },
-      "backup_box_installed":{
+      "backup_box_installed": {
         "name": "Backup-Box installed"
       },
       "backup_box_discharge_limit_percentage": {
@@ -672,13 +672,64 @@
         }
       },
       "climate_circuit_2": {
-        "name": "Climate circuit 2"
+        "name": "Climate circuit 2",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Off",
+              "reduced": "Reduced",
+              "normal": "Normal",
+              "comfort": "Comfort",
+              "fixed_value": "Fixed value",
+              "frost_protection": "Frost protection",
+              "eco_reduced": "Eco reduced",
+              "eco_normal": "Eco normal",
+              "eco_comfort": "Eco comfort",
+              "cooling_normal": "Cooling normal",
+              "cooling_comfort": "Cooling comfort"
+            }
+          }
+        }
       },
       "climate_circuit_3": {
-        "name": "Climate circuit 3"
+        "name": "Climate circuit 3",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Off",
+              "reduced": "Reduced",
+              "normal": "Normal",
+              "comfort": "Comfort",
+              "fixed_value": "Fixed value",
+              "frost_protection": "Frost protection",
+              "eco_reduced": "Eco reduced",
+              "eco_normal": "Eco normal",
+              "eco_comfort": "Eco comfort",
+              "cooling_normal": "Cooling normal",
+              "cooling_comfort": "Cooling comfort"
+            }
+          }
+        }
       },
       "climate_circuit_4": {
-        "name": "Climate circuit 4"
+        "name": "Climate circuit 4",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off_mode": "Off",
+              "reduced": "Reduced",
+              "normal": "Normal",
+              "comfort": "Comfort",
+              "fixed_value": "Fixed value",
+              "frost_protection": "Frost protection",
+              "eco_reduced": "Eco reduced",
+              "eco_normal": "Eco normal",
+              "eco_comfort": "Eco comfort",
+              "cooling_normal": "Cooling normal",
+              "cooling_comfort": "Cooling comfort"
+            }
+          }
+        }
       }
     },
     "number": {


### PR DESCRIPTION
## Description

When there is more than one Climate Circuit only the first circuit shows the tranlated status names.
Simply duplicate the translations from circuit _1 to _2 .. _4 for de and en.

## Context / Issue
