### PR TITLE
Adding DID 2760 EnergyOwnConsumption for Vitoair

### DIFF
--- a/custom_components/open3e/definitions/features.py
+++ b/custom_components/open3e/definitions/features.py
@@ -125,6 +125,7 @@ class Features:
         Cop = Feature(id=2625, refresh_interval=300)
         CopHeating = Feature(id=2622, refresh_interval=300)
         CopDhw = Feature(id=2624, refresh_interval=300)
+        EnergyOwnConsumption = Feature(id=2760, refresh_interval=300)
 
         # Vitodens
         EnergyConsumptionCentralHeating = Feature(id=548, refresh_interval=60)

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -1899,6 +1899,47 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         ),
         # Acutual intended, typo on Open3e for VentilationLevel (533)
         required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.EnergyOwnConsumption],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="energy_own_consumption_today",
+        translation_key="energy_own_consumption_today",
+        data_retriever=SensorDataRetriever.TODAY,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.EnergyOwnConsumption],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="energy_own_consumption_current_month",
+        translation_key="energy_own_consumption_current_month",
+        data_retriever=SensorDataRetriever.CURRENT_MONTH,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.EnergyOwnConsumption],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="energy_own_consumption_current_year",
+        translation_key="energy_own_consumption_current_year",
+        data_retriever=SensorDataRetriever.CURRENT_YEAR,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Energy.EnergyOwnConsumption],
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        key="energy_own_consumption_past_year",
+        translation_key="energy_own_consumption_past_year",
+        data_retriever=SensorDataRetriever.PAST_YEAR,
+        entity_registry_enabled_default=False,
+        required_device=Open3eDevices.Vitoair
     )
 )
 

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -600,6 +600,18 @@
       },
       "chimney_sweeper_test_mode": {
         "name": "Schornsteinfeger Testmodus"
+      },
+      "energy_own_consumption_today": {
+        "name": "Eigener Energieverbrauch heute"
+      },
+      "energy_own_consumption_current_month": {
+        "name": "Eigener Energieverbrauch Monat"
+      },
+      "energy_own_consumption_current_year": {
+        "name": "Eigener Energieverbrauch Jahr"
+      },
+      "energy_own_consumption_past_year": {
+        "name": "Eigener Energieverbrauch letztes Jahr"
       }
     },
     "binary_sensor": {

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -600,6 +600,18 @@
       },
       "chimney_sweeper_test_mode": {
         "name": "Chimney sweeper test mode"
+      },
+      "energy_own_consumption_today": {
+        "name": "Own energy consumption today"
+      },
+      "energy_own_consumption_current_month": {
+        "name": "Own energy consumption current month"
+      },
+      "energy_own_consumption_current_year": {
+        "name": "Own energy consumption current year"
+      },
+      "energy_own_consumption_past_year": {
+        "name": "Own energy consumption past year"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## Description

Adding DID 2760 EnergyOwnConsumption for Vitoair which is now available with the new open3e release v0.6.1. This DID shows the energy consumption of the Vitoair device.

## Context / Issue

This relates to Issue  #63 Vitoair new entities.

With my Vitoair device I want to contribute step by step to the code base and this is my first contribution (hopefully everything is according to the structure, I have checked the similar entity Features.Energy.CentralHeating and tried to derive from it). Additionally I have asked claude to validate my change against your guidelines.md and it just found some capitalization errors on the englisch translation :)