### PR TITLE
Vitoair new entities

### DIFF
--- a/custom_components/open3e/api.py
+++ b/custom_components/open3e/api.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.json import json_dumps
 from homeassistant.util.json import json_loads
 
 from custom_components.open3e.definitions.subfeatures.buffer import Buffer
+from custom_components.open3e.definitions.subfeatures.bypass_operation_state import BypassOperationState
 from custom_components.open3e.definitions.subfeatures.dmw_mode import DmwMode
 from custom_components.open3e.definitions.subfeatures.hysteresis import Hysteresis
 from custom_components.open3e.definitions.subfeatures.program import Program
@@ -597,6 +598,29 @@ class Open3eMqttClient:
             )
         except Exception as exception:
             raise Open3eError(exception)
+
+    async def async_set_bypass_operation_state(
+            self,
+            hass: HomeAssistant,
+            feature_id: int,
+            state: BypassOperationState,
+            device_id: int
+    ):
+        try:
+            _LOGGER.debug(f"Setting bypass operation state to {state} of feature ID {feature_id}")
+            await mqtt.async_publish(
+                hass=hass,
+                topic=self.__mqtt_cmd,
+                payload=self.__write_json_payload(
+                    feature_id=feature_id,
+                    data=state.map_to_api(),
+                    sub_feature="BypassStatus",
+                    device_id=device_id
+                )
+            )
+        except Exception as exception:
+            raise Open3eError(exception)
+
 
     async def async_set_circuit_pump_speed(
             self,

--- a/custom_components/open3e/coordinator.py
+++ b/custom_components/open3e/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.open3e.definitions.subfeatures.buffer import Buffer
+from custom_components.open3e.definitions.subfeatures.bypass_operation_state import BypassOperationState
 from custom_components.open3e.definitions.subfeatures.dmw_mode import DmwMode
 from custom_components.open3e.definitions.subfeatures.hysteresis import Hysteresis
 from custom_components.open3e.definitions.subfeatures.program import Program
@@ -470,6 +471,21 @@ class Open3eDataUpdateCoordinator(DataUpdateCoordinator):
             hass=self.hass,
             feature_id=feature_id,
             mode=mode,
+            device_id=device.id
+        )
+
+        self.async_refresh_feature(device, [feature_id])
+
+    async def async_set_bypass_operation_state(
+            self,
+            feature_id: int,
+            state: BypassOperationState,
+            device: Open3eDataDevice
+    ):
+        await self.__client.async_set_bypass_operation_state(
+            hass=self.hass,
+            feature_id=feature_id,
+            state=state,
             device_id=device.id
         )
 

--- a/custom_components/open3e/definitions/features.py
+++ b/custom_components/open3e/definitions/features.py
@@ -191,6 +191,13 @@ class Features:
         FlowCircuit4HeatingCurve = Feature(id=883, refresh_interval=30)
         VentilationMode = Feature(id=2371, refresh_interval=30)
         VentilationLevel = Feature(id=533, refresh_interval=30)
+        BypassOperationState = Feature(id=437, refresh_interval=30)
+        BypassAvailableModes = Feature(id=439, refresh_interval=30)
+        OutsideAirBypass = Feature(id=1088, refresh_interval=30)
+        InsideAirBypass = Feature(id=1089, refresh_interval=30)
+        BypassOperationLevel = Feature(id=2403, refresh_interval=30)
+        VentilationBypassPosition = Feature(id=2493, refresh_interval=30)
+        VentilationBypassFlapAvailableCount = Feature(id=2797, refresh_interval=30)
 
         # Pump-Status und Kältekreis
         CentralHeatingPumpStatus = Feature(id=2791, refresh_interval=10)

--- a/custom_components/open3e/definitions/select.py
+++ b/custom_components/open3e/definitions/select.py
@@ -8,6 +8,7 @@ from .entity_description import Open3eEntityDescription
 from .features import Features
 from .open3e_data import Open3eDataDevice
 from .subfeatures.buffer_mode import BufferMode
+from .subfeatures.bypass_operation_state import BypassOperationState, get_bypass_operation_state
 from .. import Open3eDataUpdateCoordinator
 
 
@@ -44,6 +45,22 @@ SELECTS: tuple[Open3eSelectEntityDescription, ...] = (
     ###############
     ### VITOAIR ###
     ###############
+
+    Open3eSelectEntityDescription(
+        poll_data_features=[Features.State.BypassOperationState],
+        options=[BypassOperationState.Closed, BypassOperationState.Automatic, BypassOperationState.Open,
+                 BypassOperationState.TransitionError],
+        get_option=lambda data: get_bypass_operation_state(data),
+        set_option=lambda option, device, coordinator: coordinator.async_set_bypass_operation_state(
+            feature_id=Features.State.BypassOperationState.id,
+            state=BypassOperationState.from_str(option),
+            device=device
+        ),
+        icon="mdi:valve-open",
+        key="ventilation_bypass_operation_state",
+        translation_key="ventilation_bypass_operation_state",
+        required_device=Open3eDevices.Vitoair
+    ),
 
     # Open3eSelectEntityDescription(
     #     poll_data_features=[Features.State.CurrentQuickMode],

--- a/custom_components/open3e/definitions/select.py
+++ b/custom_components/open3e/definitions/select.py
@@ -18,7 +18,7 @@ class Open3eSelectEntityDescription(
 ):
     """Default number entity description for open3e."""
     domain: str = "select"
-    get_option: Callable[[Any], str] = None
+    get_option: Callable[[Any], str | None] = None
     set_option: Callable[[str, Open3eDataDevice, Open3eDataUpdateCoordinator], Awaitable[None]] = None
 
 

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -11,6 +11,7 @@ from homeassistant.util.json import json_loads
 from .devices import Open3eDevices
 from .entity_description import Open3eEntityDescription
 from .features import Features
+from .subfeatures.bypass_operation_level import BypassOperationLevel, get_bypass_operation_level
 from .subfeatures.connection_status import ConnectionStatus, get_connection_status
 from .subfeatures.domestic_hot_water_operation_state import (
     DomesticHotWaterOperationState,
@@ -2232,6 +2233,70 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         ),
         # Acutual intended, typo on Open3e for VentilationLevel (533)
         required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.BypassAvailableModes],
+        key="ventilation_bypass_available_modes",
+        translation_key="ventilation_bypass_available_modes",
+        icon="mdi:cog-outline",
+        data_retriever=SensorDataRetriever.RAW,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.OutsideAirBypass],
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="ventilation_outside_air_bypass",
+        translation_key="ventilation_outside_air_bypass",
+        icon="mdi:thermometer-minus",
+        data_retriever=SensorDataRetriever.RAW,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.InsideAirBypass],
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="ventilation_inside_air_bypass",
+        translation_key="ventilation_inside_air_bypass",
+        icon="mdi:thermometer-plus",
+        data_retriever=SensorDataRetriever.RAW,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.VentilationBypassPosition],
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="ventilation_bypass_position",
+        translation_key="ventilation_bypass_position",
+        icon="mdi:valve",
+        data_retriever=SensorDataRetriever.RAW,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.VentilationBypassFlapAvailableCount],
+        state_class=SensorStateClass.MEASUREMENT,
+        key="ventilation_bypass_flap_available_count",
+        translation_key="ventilation_bypass_flap_available_count",
+        icon="mdi:counter",
+        data_retriever=SensorDataRetriever.RAW,
+        required_device=Open3eDevices.Vitoair
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.State.BypassOperationLevel],
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            BypassOperationLevel.Off,
+            BypassOperationLevel.Dynamic,
+            BypassOperationLevel.Soft,
+            BypassOperationLevel.Manual,
+        ],
+        icon="mdi:cog-transfer",
+        key="ventilation_bypass_operation_level",
+        translation_key="ventilation_bypass_operation_level",
+        data_retriever=get_bypass_operation_level,
+        required_device=Open3eDevices.Vitoair,
     ),
     Open3eSensorEntityDescription(
         poll_data_features=[Features.Energy.EnergyOwnConsumption],

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -2280,7 +2280,7 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         key="ventilation_bypass_flap_available_count",
         translation_key="ventilation_bypass_flap_available_count",
         icon="mdi:counter",
-        data_retriever=SensorDataRetriever.RAW,
+        data_retriever=lambda value: int(value),
         required_device=Open3eDevices.Vitoair
     ),
     Open3eSensorEntityDescription(

--- a/custom_components/open3e/definitions/subfeatures/bypass_operation_level.py
+++ b/custom_components/open3e/definitions/subfeatures/bypass_operation_level.py
@@ -9,7 +9,6 @@ class BypassOperationLevel(StrEnum):
     Dynamic = "dynamic"
     Soft = "soft"
     Manual = "manual"
-    Unknown = "unknown"
 
 
 def get_bypass_operation_level(data: Any) -> BypassOperationLevel | None:
@@ -35,6 +34,6 @@ def get_bypass_operation_level(data: Any) -> BypassOperationLevel | None:
             case 3:
                 return BypassOperationLevel.Manual
             case _:
-                return BypassOperationLevel.Unknown
+                return None
     except (TypeError, ValueError, KeyError):
         return None

--- a/custom_components/open3e/definitions/subfeatures/bypass_operation_level.py
+++ b/custom_components/open3e/definitions/subfeatures/bypass_operation_level.py
@@ -1,0 +1,40 @@
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.util.json import json_loads
+
+
+class BypassOperationLevel(StrEnum):
+    Off = "off"
+    Dynamic = "dynamic"
+    Soft = "soft"
+    Manual = "manual"
+    Unknown = "unknown"
+
+
+def get_bypass_operation_level(data: Any) -> BypassOperationLevel | None:
+    try:
+        # DID 2403 is O3EByteVal (simple integer) according to Open3Edatapoints.py
+        # but let's handle complex structure too just in case it's actually O3EEnum
+        if isinstance(data, str) and data.strip().startswith("{"):
+            payload = json_loads(data)
+            raw_id = payload.get("ID")
+            if raw_id is None:
+                return None
+            value = int(raw_id)
+        else:
+            value = int(data)
+
+        match value:
+            case 0:
+                return BypassOperationLevel.Off
+            case 1:
+                return BypassOperationLevel.Dynamic
+            case 2:
+                return BypassOperationLevel.Soft
+            case 3:
+                return BypassOperationLevel.Manual
+            case _:
+                return BypassOperationLevel.Unknown
+    except (TypeError, ValueError, KeyError):
+        return None

--- a/custom_components/open3e/definitions/subfeatures/bypass_operation_state.py
+++ b/custom_components/open3e/definitions/subfeatures/bypass_operation_state.py
@@ -1,0 +1,63 @@
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.util.json import json_loads
+
+
+class BypassOperationState(StrEnum):
+    Closed = "closed"
+    Automatic = "automatic"
+    Open = "open"
+    TransitionError = "transition_error"
+    Unknown = "unknown"
+
+    @staticmethod
+    def from_str(mode: str):
+        match mode:
+            case "closed":
+                return BypassOperationState.Closed
+            case "automatic":
+                return BypassOperationState.Automatic
+            case "open":
+                return BypassOperationState.Open
+            case "transition_error":
+                return BypassOperationState.TransitionError
+        return None
+
+    def map_to_api(self):
+        match self:
+            case BypassOperationState.Closed:
+                return 0
+            case BypassOperationState.Automatic:
+                return 1
+            case BypassOperationState.Open:
+                return 2
+            case BypassOperationState.TransitionError:
+                return 3
+        return None
+
+
+def get_bypass_operation_state(data: Any) -> BypassOperationState:
+    try:
+        if isinstance(data, str) and data.strip().startswith("{"):
+            payload = json_loads(data)
+            raw_id = payload.get("BypassStatus")
+            if raw_id is None:
+                return BypassOperationState.Unknown
+            value = int(raw_id)
+        else:
+            return BypassOperationState.Unknown
+
+        match value:
+            case 0:
+                return BypassOperationState.Closed
+            case 1:
+                return BypassOperationState.Automatic
+            case 2:
+                return BypassOperationState.Open
+            case 3:
+                return BypassOperationState.TransitionError
+            case _:
+                return BypassOperationState.Unknown
+    except (TypeError, ValueError, KeyError):
+        return BypassOperationState.Unknown

--- a/custom_components/open3e/definitions/subfeatures/bypass_operation_state.py
+++ b/custom_components/open3e/definitions/subfeatures/bypass_operation_state.py
@@ -9,7 +9,6 @@ class BypassOperationState(StrEnum):
     Automatic = "automatic"
     Open = "open"
     TransitionError = "transition_error"
-    Unknown = "unknown"
 
     @staticmethod
     def from_str(mode: str):
@@ -37,16 +36,16 @@ class BypassOperationState(StrEnum):
         return None
 
 
-def get_bypass_operation_state(data: Any) -> BypassOperationState:
+def get_bypass_operation_state(data: Any) -> BypassOperationState | None:
     try:
         if isinstance(data, str) and data.strip().startswith("{"):
             payload = json_loads(data)
             raw_id = payload.get("BypassStatus")
             if raw_id is None:
-                return BypassOperationState.Unknown
+                return None
             value = int(raw_id)
         else:
-            return BypassOperationState.Unknown
+            return None
 
         match value:
             case 0:
@@ -58,6 +57,6 @@ def get_bypass_operation_state(data: Any) -> BypassOperationState:
             case 3:
                 return BypassOperationState.TransitionError
             case _:
-                return BypassOperationState.Unknown
+                return None
     except (TypeError, ValueError, KeyError):
-        return BypassOperationState.Unknown
+        return None

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -413,7 +413,7 @@
         "name": "Lüftungsstufe"
       },
       "ventilation_bypass_available_modes": {
-        "name": "Bypass-Verfügbare Modi"
+        "name": "Verfügbare Bypass-Modi"
       },
       "ventilation_outside_air_bypass": {
         "name": "Außenluft-Bypass"

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -412,6 +412,41 @@
       "ventilation_level": {
         "name": "Lüftungsstufe"
       },
+      "ventilation_bypass_operation_state": {
+        "name": "Bypass-Betriebszustand",
+        "state": {
+          "closed": "Geschlossen",
+          "automatic": "Automatik",
+          "open": "Offen",
+          "transition_error": "Übergang/Fehler",
+          "unknown": "Unbekannt"
+        }
+      },
+      "ventilation_bypass_available_modes": {
+        "name": "Bypass-Verfügbare Modi"
+      },
+      "ventilation_outside_air_bypass": {
+        "name": "Außenluft-Bypass"
+      },
+      "ventilation_inside_air_bypass": {
+        "name": "Innenluft-Bypass"
+      },
+      "ventilation_bypass_operation_level": {
+        "name": "Bypass-Betriebsstufe",
+        "state": {
+          "off": "Aus",
+          "dynamic": "Dynamisch",
+          "soft": "Sanft",
+          "manual": "Manuell",
+          "unknown": "Unbekannt"
+        }
+      },
+      "ventilation_bypass_position": {
+        "name": "Bypass-Position"
+      },
+      "ventilation_bypass_flap_available_count": {
+        "name": "Bypass-Klappe Anzahl verfügbar"
+      },
       "domestic_hot_water_operation_state_text": {
         "name": "Warmwasser-Betriebsstatus",
         "state": {

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -412,16 +412,6 @@
       "ventilation_level": {
         "name": "Lüftungsstufe"
       },
-      "ventilation_bypass_operation_state": {
-        "name": "Bypass-Betriebszustand",
-        "state": {
-          "closed": "Geschlossen",
-          "automatic": "Automatik",
-          "open": "Offen",
-          "transition_error": "Übergang/Fehler",
-          "unknown": "Unbekannt"
-        }
-      },
       "ventilation_bypass_available_modes": {
         "name": "Bypass-Verfügbare Modi"
       },
@@ -1102,6 +1092,16 @@
           "intensive": "Intensivlüftung",
           "reduced_noise": "Reduzierte Lüftung",
           "off": "Aus"
+        }
+      },
+      "ventilation_bypass_operation_state": {
+        "name": "Bypass-Betriebszustand",
+        "state": {
+          "closed": "Geschlossen",
+          "automatic": "Automatik",
+          "open": "Offen",
+          "transition_error": "Übergang/Fehler",
+          "unknown": "Unbekannt"
         }
       }
     },

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -412,16 +412,6 @@
       "ventilation_level": {
         "name": "Ventilation level"
       },
-      "ventilation_bypass_operation_state": {
-        "name": "Bypass operation state",
-        "state": {
-          "closed": "Closed",
-          "automatic": "Automatic",
-          "open": "Open",
-          "transition_error": "Transition/Error",
-          "unknown": "Unknown"
-        }
-      },
       "ventilation_bypass_available_modes": {
         "name": "Bypass available modes"
       },
@@ -1102,6 +1092,16 @@
           "intensive": "Intensive ventilation",
           "reduced_noise": "Reduced noise",
           "off": "Off"
+        }
+      },
+      "ventilation_bypass_operation_state": {
+        "name": "Bypass operation state",
+        "state": {
+          "closed": "Closed",
+          "automatic": "Automatic",
+          "open": "Open",
+          "transition_error": "Transition/Error",
+          "unknown": "Unknown"
         }
       }
     },

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -412,6 +412,41 @@
       "ventilation_level": {
         "name": "Ventilation level"
       },
+      "ventilation_bypass_operation_state": {
+        "name": "Bypass operation state",
+        "state": {
+          "closed": "Closed",
+          "automatic": "Automatic",
+          "open": "Open",
+          "transition_error": "Transition/Error",
+          "unknown": "Unknown"
+        }
+      },
+      "ventilation_bypass_available_modes": {
+        "name": "Bypass available modes"
+      },
+      "ventilation_outside_air_bypass": {
+        "name": "Outside air bypass"
+      },
+      "ventilation_inside_air_bypass": {
+        "name": "Inside air bypass"
+      },
+      "ventilation_bypass_operation_level": {
+        "name": "Bypass operation level",
+        "state": {
+          "off": "Off",
+          "dynamic": "Dynamic",
+          "soft": "Soft",
+          "manual": "Manual",
+          "unknown": "Unknown"
+        }
+      },
+      "ventilation_bypass_position": {
+        "name": "Bypass position"
+      },
+      "ventilation_bypass_flap_available_count": {
+        "name": "Bypass flap available count"
+      },
       "domestic_hot_water_operation_state_text": {
         "name": "Hot water operation status",
         "state": {


### PR DESCRIPTION
## Description

Added new vitoair entities

- 437 | BypassOperationState
- 439 | BypassAvailableModes
- 1088 | OutsideAirBypass
- 1089 | InsideAirBypass
- 2403 | BypassOperationLevel
- 2493 | VentilationBypassPosition
- 2797 | VentilationBypassFlapAvailableCount

## Context / Issue

https://github.com/MojoOli/open3e-ha/issues/63#issuecomment-4231829759