### PR TITLE
Add DHW buffer layered sensors (DIDs 3232/3233/3234)

### DIFF
--- a/custom_components/open3e/definitions/features.py
+++ b/custom_components/open3e/definitions/features.py
@@ -69,6 +69,9 @@ class Features:
         HeatingBuffer = Feature(id=3016, refresh_interval=30)
         CoolingBuffer = Feature(id=3017, refresh_interval=30)
         HeatingCoolingBuffer = Feature(id=3018, refresh_interval=30)
+        DhwBufferBottom = Feature(id=3232, refresh_interval=30)
+        DhwBufferMid = Feature(id=3233, refresh_interval=30)
+        DhwBufferTop = Feature(id=3234, refresh_interval=30)
         DomesticHotWaterHysteresis = Feature(id=1085, refresh_interval=30)
 
         # Vitodens

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -1346,6 +1346,36 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         required_device=Open3eDevices.Vitocal
     ),
     Open3eSensorEntityDescription(
+        poll_data_features=[Features.Temperature.DhwBufferBottom],
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="dhw_buffer_bottom_temperature",
+        translation_key="dhw_buffer_bottom_temperature",
+        data_retriever=SensorDataRetriever.ACTUAL,
+        required_device=Open3eDevices.Vitocal
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Temperature.DhwBufferMid],
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="dhw_buffer_mid_temperature",
+        translation_key="dhw_buffer_mid_temperature",
+        data_retriever=SensorDataRetriever.ACTUAL,
+        required_device=Open3eDevices.Vitocal
+    ),
+    Open3eSensorEntityDescription(
+        poll_data_features=[Features.Temperature.DhwBufferTop],
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        key="dhw_buffer_top_temperature",
+        translation_key="dhw_buffer_top_temperature",
+        data_retriever=SensorDataRetriever.ACTUAL,
+        required_device=Open3eDevices.Vitocal
+    ),
+    Open3eSensorEntityDescription(
         poll_data_features=[Features.State.EnergyManagement],
         device_class=SensorDeviceClass.ENUM,
         icon="mdi:home-battery-outline",

--- a/custom_components/open3e/definitions/sensors.py
+++ b/custom_components/open3e/definitions/sensors.py
@@ -1352,6 +1352,7 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         key="dhw_buffer_bottom_temperature",
         translation_key="dhw_buffer_bottom_temperature",
+        icon="mdi:water-thermometer",
         data_retriever=SensorDataRetriever.ACTUAL,
         required_device=Open3eDevices.Vitocal
     ),
@@ -1362,6 +1363,7 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         key="dhw_buffer_mid_temperature",
         translation_key="dhw_buffer_mid_temperature",
+        icon="mdi:water-thermometer",
         data_retriever=SensorDataRetriever.ACTUAL,
         required_device=Open3eDevices.Vitocal
     ),
@@ -1372,6 +1374,7 @@ SENSORS: tuple[Open3eSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         key="dhw_buffer_top_temperature",
         translation_key="dhw_buffer_top_temperature",
+        icon="mdi:water-thermometer",
         data_retriever=SensorDataRetriever.ACTUAL,
         required_device=Open3eDevices.Vitocal
     ),

--- a/custom_components/open3e/translations/de.json
+++ b/custom_components/open3e/translations/de.json
@@ -340,6 +340,15 @@
       "heating_cooling_buffer_temperature": {
         "name": "Heiz-/Kühlpuffertemperatur"
       },
+      "dhw_buffer_bottom_temperature": {
+        "name": "Warmwasserspeicher Unten"
+      },
+      "dhw_buffer_mid_temperature": {
+        "name": "Warmwasserspeicher Mitte"
+      },
+      "dhw_buffer_top_temperature": {
+        "name": "Warmwasserspeicher Oben"
+      },
       "energy_management_mode": {
         "name": "SmartGrid Betriebszustand",
         "state": {

--- a/custom_components/open3e/translations/en.json
+++ b/custom_components/open3e/translations/en.json
@@ -340,6 +340,15 @@
       "heating_cooling_buffer_temperature": {
         "name": "Heating/cooling buffer temperature"
       },
+      "dhw_buffer_bottom_temperature": {
+        "name": "DHW buffer bottom"
+      },
+      "dhw_buffer_mid_temperature": {
+        "name": "DHW buffer mid"
+      },
+      "dhw_buffer_top_temperature": {
+        "name": "DHW buffer top"
+      },
       "energy_management_mode": {
         "name": "SmartGrid operating state",
         "state": {


### PR DESCRIPTION
Adds three new temperature sensors for the domestic hot water buffer bottom/mid/top layers, exposed via DIDs 3232, 3233 and 3234. These are present on Vitocal DHW heat pumps (e.g. Vitocal 262a) and allow monitoring the stratification of the hot water tank.

- features.py: register DhwBufferBottom/Mid/Top (IDs 3232/3233/3234)
- sensors.py: add three Open3eSensorEntityDescription entries
- translations: add de/en names

## Description

<!-- Provide a concise description of the changes in this PR. What does it do? -->

## Context / Issue

<!-- Reference the issue it resolves, for instance: Resolves #123 -->